### PR TITLE
Use TF reference for aws_lambda_permission

### DIFF
--- a/chalice/package.py
+++ b/chalice/package.py
@@ -925,7 +925,7 @@ class TerraformGenerator(TemplateGenerator):
         template['resource'].setdefault(
             'aws_lambda_permission', {})[
             resource.resource_name] = {
-            'function_name': resource.lambda_function.function_name,
+            'function_name': self._fref(resource.lambda_function, attr='function_name'),
             'action': 'lambda:InvokeFunction',
             'principal': self._options.service_principal('events'),
             'source_arn': "${aws_cloudwatch_event_rule.%s.arn}" % (

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ install_requires = [
 
 setup(
     name='chalice',
-    version='1.18.0+5',
+    version='1.18.0+6',
     description="Microframework",
     long_description=README,
     author="James Saryerwinnie",


### PR DESCRIPTION
This was accidentally omitted from 36de57ddd5753ae5ee97fd59cc8bd951cb4ac2ce and caused https://github.com/DataBiosphere/azul/issues/1672 to crop up again.