### PR TITLE
Rebase onto aws/chalice@1.24.1 (DataBiosphere/azul#3290)

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,13 @@
+name: Add `orange` label to new issues and PR's
+on: [issues, pull_request_target]
+jobs:
+  label:
+    permissions:
+      issues: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: DataBiosphere/azul-github-labeler-action@releases/v5
+      with:
+        repo-token: "${{secrets.GITHUB_TOKEN}}"
+        label: orange

--- a/chalice/awsclient.py
+++ b/chalice/awsclient.py
@@ -1667,6 +1667,7 @@ class TypedAWSClient(object):
             'EventSourceArn': event_source_arn,
             'FunctionName': function_name,
             'BatchSize': batch_size,
+            'Enabled': True
         }
         if starting_position is not None:
             kwargs['StartingPosition'] = starting_position
@@ -1680,7 +1681,7 @@ class TypedAWSClient(object):
         lambda_client = self._client('lambda')
         self._call_client_method_with_retries(
             lambda_client.update_event_source_mapping,
-            {'UUID': event_uuid, 'BatchSize': batch_size},
+            {'UUID': event_uuid, 'BatchSize': batch_size, 'Enabled': True},
             max_attempts=10,
             should_retry=self._is_settling_error,
         )

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ install_requires = [
 
 setup(
     name='chalice',
-    version='1.24.1',
+    version='1.24.1+7',
     description="Microframework",
     long_description=README,
     author="James Saryerwinnie",


### PR DESCRIPTION
DataBiosphere/azul#3290

I pushed a new branch to azul-chalice: hotfix/1.24.1/azul-updates. This branch is the same as Chalice's release tag for 1.24.1. It is the target branch for this PR which adds Azul's customizations.

This PR adds Azul's customizations on top of Chalice's latest release.