### PR TITLE
Rebase onto aws/chalice@1.27.0 (DataBiosphere/azul#4146)

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,13 @@
+name: Add `orange` label to new issues and PR's
+on: [issues, pull_request_target]
+jobs:
+  label:
+    permissions:
+      issues: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: DataBiosphere/azul-github-labeler-action@releases/v5
+      with:
+        repo-token: "${{secrets.GITHUB_TOKEN}}"
+        label: orange

--- a/chalice/awsclient.py
+++ b/chalice/awsclient.py
@@ -1669,7 +1669,8 @@ class TypedAWSClient(object):
             'EventSourceArn': event_source_arn,
             'FunctionName': function_name,
             'BatchSize': batch_size,
-            'MaximumBatchingWindowInSeconds': batch_window
+            'MaximumBatchingWindowInSeconds': batch_window,
+            'Enabled': True
         }
         if starting_position is not None:
             kwargs['StartingPosition'] = starting_position
@@ -1687,6 +1688,7 @@ class TypedAWSClient(object):
             'UUID': event_uuid,
             'BatchSize': batch_size,
             'MaximumBatchingWindowInSeconds': batch_window,
+            'Enabled': True,
         }
         self._call_client_method_with_retries(
             lambda_client.update_event_source_mapping, kwargs,

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ install_requires = [
 
 setup(
     name='chalice',
-    version='1.27.0',
+    version='1.27.0+8',
     description="Microframework",
     long_description=README,
     author="James Saryerwinnie",


### PR DESCRIPTION
https://github.com/DataBiosphere/azul/issues/4146

Branch `azul-chalice: hotfix/1.27.0/azul-updates` is the same as Chalice's release tag for `1.27.0`, and is the target branch for this PR which adds Azul's customizations.

This PR adds Azul's customizations on top of Chalice's latest release (v1.27.0).